### PR TITLE
Add option for 'clickable linter messages'

### DIFF
--- a/gitlint/__init__.py
+++ b/gitlint/__init__.py
@@ -27,14 +27,15 @@ Usage:
     git-lint -h | --version
 
 Options:
-    -h             Show the usage patterns.
-    --version      Prints the version number.
-    -f --force     Shows all the lines with problems.
-    -t --tracked   Lints only tracked files.
-    --json         Prints the result as a json string. Useful to use it in
-                   conjunction with other tools.
-    --last-commit  Checks the last checked-out commit. This is mostly useful
-                   when used as: git checkout <revid>; git lint --last-commit.
+    -h              Show the usage patterns.
+    --version       Prints the version number.
+    -f --force      Shows all the lines with problems.
+    -t --tracked    Lints only tracked files.
+    --json          Prints the result as a json string. Useful to use it in
+                    conjunction with other tools.
+    --last-commit   Checks the last checked-out commit. This is mostly useful
+                    when used as: git checkout <revid>; git lint --last-commit.
+    --since-commit  Checks all the commits since the specified commit.
 """
 
 from __future__ import unicode_literals

--- a/gitlint/linters.py
+++ b/gitlint/linters.py
@@ -116,6 +116,7 @@ def lint_command(name, program, arguments, filter_regex, filename, lines):
             comment['column'] = int(comment['column'])
         if 'severity' in comment:
             comment['severity'] = comment['severity'].title()
+        comment['filename'] = os.path.relpath(filename)
         result.append(comment)
 
     return {filename: {'comments': result}}


### PR DESCRIPTION
add support for `--clickable-messages` command line param.  
when used, linter errors have their source location in `file:number` format.
in VSCode this enable Ctrl+Click them, to jump to the linter's erroneous line.
e.g.:

*The output now is like this:*
```shell
Linting file: scenarios/sharp_jobs_query.py
scenarios/sharp_jobs_query.py:94:4: Convention: [line-too-long]:: Line too long (158/100)
```

*Instead of this:*
```shell
Linting file: scenarios/sharp_jobs_query.py
line 94, col 0: Convention: [line-too-long]: Line too long (158/100)
````

